### PR TITLE
use choco install aqt

### DIFF
--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Find Qt Assistant (Windows)
       if: matrix.os == 'windows-latest'
       run: |
-        choco install qt6-base
+        choco install aqt
         $assistantPath = Get-ChildItem -Path "C:\" -Recurse -Filter "assistant.exe" -ErrorAction SilentlyContinue | Where-Object { $_.FullName -like "*Qt6*" } | Select-Object -First 1 -ExpandProperty FullName
         echo "ASSISTANT_PATH=$assistantPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 

--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Find Qt Assistant (Windows)
       if: matrix.os == 'windows-latest'
       run: |
-        choco install aqt
+        choco install aqt -y --no-progress
         $assistantPath = Get-ChildItem -Path "C:\" -Recurse -Filter "assistant.exe" -ErrorAction SilentlyContinue | Where-Object { $_.FullName -like "*Qt6*" } | Select-Object -First 1 -ExpandProperty FullName
         echo "ASSISTANT_PATH=$assistantPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 


### PR DESCRIPTION
there isn't a qt6 on choco (qt5-default, but not qt6)

## Summary by Sourcery

CI:
- Replace ‘choco install qt6-base’ with ‘choco install aqt’ in the Windows build-executables workflow to correctly locate Qt6’s assistant.exe