### PR TITLE
simplify building of executables

### DIFF
--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -123,7 +123,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       shell: bash
       run: |
-        poetry run pyinstaller --name=dcmQTreePy --windowed --icon=help/icons/app_icon.png --add-data="help;help" dcmqtreepy/dcmQTree.py
+        poetry run pyinstaller --onefile --name=dcmQTreePy --windowed --icon=help/icons/app_icon.png --add-data="help;help" dcmqtreepy/dcmQTree.py
 
     # - name: Create distribution package (macOS/Linux)
     #   if: matrix.os != 'windows-latest'

--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Find Qt Assistant (Windows)
       if: matrix.os == 'windows-latest'
       run: |
-        choco install qt6-base
+        choco install aqt
         $assistantPath = Get-ChildItem -Path "C:\" -Recurse -Filter "assistant.exe" -ErrorAction SilentlyContinue | Where-Object { $_.FullName -like "*Qt6*" } | Select-Object -First 1 -ExpandProperty FullName
         echo "ASSISTANT_PATH=$assistantPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 

--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -42,85 +42,86 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
-    - name: Find Qt Assistant (macOS)
-      if: matrix.os == 'macos-latest'
-      run: |
-        brew install qt@6
-        echo "ASSISTANT_PATH=$(find /opt/homebrew -name assistant -type f | grep -v Assistant.app | head -n 1)" >> $GITHUB_ENV
+    # - name: Find Qt Assistant (macOS)
+    #   if: matrix.os == 'macos-latest'
+    #   run: |
+    #     brew install qt@6
+    #     echo "ASSISTANT_PATH=$(find /opt/homebrew -name assistant -type f | grep -v Assistant.app | head -n 1)" >> $GITHUB_ENV
 
-    - name: Find Qt Assistant (Ubuntu)
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y qt6-tools-dev qt6-documentation-tools qt6-base-dev
-        echo "ASSISTANT_PATH=$(find /usr -name assistant -type f | grep -v Assistant.app | head -n 1)" >> $GITHUB_ENV
+    # - name: Find Qt Assistant (Ubuntu)
+    #   if: matrix.os == 'ubuntu-latest'
+    #   run: |
+    #     sudo apt-get update
+    #     sudo apt-get install -y qt6-tools-dev qt6-documentation-tools qt6-base-dev
+    #     echo "ASSISTANT_PATH=$(find /usr -name assistant -type f | grep -v Assistant.app | head -n 1)" >> $GITHUB_ENV
 
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v4
+    # - name: Install Qt
+    #   uses: jurplel/install-qt-action@v4
 
-    - name: Find Qt Assistant (Windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        $assistantPath = Get-ChildItem -Path "C:\" -Recurse -Filter "assistant.exe" -ErrorAction SilentlyContinue | Where-Object { $_.FullName -like "*Qt6*" } | Select-Object -First 1 -ExpandProperty FullName
-        echo "ASSISTANT_PATH=$assistantPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+    # - name: Find Qt Assistant (Windows)
+    #   if: matrix.os == 'windows-latest'
+    #   run: |
+    #     $assistantPath = Get-ChildItem -Path "C:\" -Recurse -Filter "assistant.exe" -ErrorAction SilentlyContinue | Where-Object { $_.FullName -like "*Qt6*" } | Select-Object -First 1 -ExpandProperty FullName
+    #     echo "ASSISTANT_PATH=$assistantPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Install dependencies with Poetry
       run: |
         poetry install --with=dev
 
-    - name: Verify Qt Assistant installation
-      run: |
-        echo "Looking for Qt Assistant..."
-        echo "Configured path: $ASSISTANT_PATH"
+    # - name: Verify Qt Assistant installation
+    #   run: |
+    #     echo "Looking for Qt Assistant..."
+    #     echo "Configured path: $ASSISTANT_PATH"
 
-        # If the path is empty or doesn't exist, search for it
-        if [ ! -f "$ASSISTANT_PATH" ]; then
-          echo "Assistant not found at configured path. Searching..."
+    #     # If the path is empty or doesn't exist, search for it
+    #     if [ ! -f "$ASSISTANT_PATH" ]; then
+    #       echo "Assistant not found at configured path. Searching..."
 
-          if [ "${{ matrix.os }}" = "macos-latest" ]; then
-            echo "Searching in homebrew paths..."
-            FOUND_PATH=$(find /opt/homebrew -name assistant -type f | grep -v Assistant.app | head -n 1)
-          elif [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-            echo "Searching in system paths..."
-            FOUND_PATH=$(find /usr -name assistant -type f | grep -v Assistant.app | head -n 1)
-          elif [ "${{ matrix.os }}" = "windows-latest" ]; then
-            echo "Searching in Windows paths..."
-            FOUND_PATH=$(PowerShell -Command "Get-ChildItem -Path C:\ -Recurse -Filter assistant.exe -ErrorAction SilentlyContinue | Where-Object { \$_.FullName -like '*Qt6*' } | Select-Object -First 1 -ExpandProperty FullName")
-          fi
+    #       if [ "${{ matrix.os }}" = "macos-latest" ]; then
+    #         echo "Searching in homebrew paths..."
+    #         FOUND_PATH=$(find /opt/homebrew -name assistant -type f | grep -v Assistant.app | head -n 1)
+    #       elif [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+    #         echo "Searching in system paths..."
+    #         FOUND_PATH=$(find /usr -name assistant -type f | grep -v Assistant.app | head -n 1)
+    #       elif [ "${{ matrix.os }}" = "windows-latest" ]; then
+    #         echo "Searching in Windows paths..."
+    #         FOUND_PATH=$(PowerShell -Command "Get-ChildItem -Path C:\ -Recurse -Filter assistant.exe -ErrorAction SilentlyContinue | Where-Object { \$_.FullName -like '*Qt6*' } | Select-Object -First 1 -ExpandProperty FullName")
+    #       fi
 
-          if [ -n "$FOUND_PATH" ] && [ -f "$FOUND_PATH" ]; then
-            echo "Found assistant at: $FOUND_PATH"
-            echo "ASSISTANT_PATH=$FOUND_PATH" >> $GITHUB_ENV
-          else
-            echo "⚠️ Qt Assistant not found! Showing search results:"
-            if [ "${{ matrix.os }}" = "macos-latest" ]; then
-              find /opt/homebrew -name assistant -type f
-            elif [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-              find /usr -name assistant -type f
-            elif [ "${{ matrix.os }}" = "windows-latest" ]; then
-              PowerShell -Command "Get-ChildItem -Path C:\ -Recurse -Filter assistant.exe -ErrorAction SilentlyContinue | Select-Object -First 10 FullName"
-            fi
-            echo "❌ Error: Qt Assistant not found. Build may fail."
-          fi
-        else
-          echo "✅ Qt Assistant found at $ASSISTANT_PATH"
-        fi
-      shell: bash
+    #       if [ -n "$FOUND_PATH" ] && [ -f "$FOUND_PATH" ]; then
+    #         echo "Found assistant at: $FOUND_PATH"
+    #         echo "ASSISTANT_PATH=$FOUND_PATH" >> $GITHUB_ENV
+    #       else
+    #         echo "⚠️ Qt Assistant not found! Showing search results:"
+    #         if [ "${{ matrix.os }}" = "macos-latest" ]; then
+    #           find /opt/homebrew -name assistant -type f
+    #         elif [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+    #           find /usr -name assistant -type f
+    #         elif [ "${{ matrix.os }}" = "windows-latest" ]; then
+    #           PowerShell -Command "Get-ChildItem -Path C:\ -Recurse -Filter assistant.exe -ErrorAction SilentlyContinue | Select-Object -First 10 FullName"
+    #         fi
+    #         echo "❌ Error: Qt Assistant not found. Build may fail."
+    #       fi
+    #     else
+    #       echo "✅ Qt Assistant found at $ASSISTANT_PATH"
+    #     fi
+    #   shell: bash
 
     - name: Build with PyInstaller (macOS)
       if: matrix.os == 'macos-latest'
       run: |
-        poetry run pyinstaller --name=dcmQTreePy --windowed --icon=help/icons/app_icon.png --add-data="help:help" --add-binary="${ASSISTANT_PATH}:." dcmqtreepy/dcmQTree.py
+        # poetry run pyinstaller --name=dcmQTreePy --windowed --icon=help/icons/app_icon.png --add-data="help:help" --add-binary="${ASSISTANT_PATH}:." dcmqtreepy/dcmQTree.py
+        poetry run pyinstaller --name=dcmQTreePy --windowed --icon=help/icons/app_icon.png --add-data="help:help" dcmqtreepy/dcmQTree.py
 
     - name: Build with PyInstaller (Ubuntu)
       if: matrix.os == 'ubuntu-latest'
       run: |
-        poetry run pyinstaller --name=dcmQTreePy --windowed --icon=help/icons/app_icon.png --add-data="help:help" --add-binary="${ASSISTANT_PATH}:." dcmqtreepy/dcmQTree.py
+        poetry run pyinstaller --name=dcmQTreePy --windowed --icon=help/icons/app_icon.png --add-data="help:help" dcmqtreepy/dcmQTree.py
 
     - name: Build with PyInstaller (Windows)
       if: matrix.os == 'windows-latest'
       run: |
-        poetry run pyinstaller --name=dcmQTreePy --windowed --icon=help/icons/app_icon.png --add-data="help;help" --add-binary="$env:ASSISTANT_PATH;." dcmqtreepy/dcmQTree.py
+        poetry run pyinstaller --name=dcmQTreePy --windowed --icon=help/icons/app_icon.png --add-data="help;help" dcmqtreepy/dcmQTree.py
 
     - name: Create distribution package (macOS/Linux)
       if: matrix.os != 'windows-latest'
@@ -139,11 +140,12 @@ jobs:
 
     - name: Create distribution package (Windows)
       if: matrix.os == 'windows-latest'
+      shell: pwsh
       run: |
         mkdir dist-package
         cp -r dist/dcmQTreePy dist-package/
         Compress-Archive -Path dist-package/* -DestinationPath dist/dcmQTreePy-windows.zip
-      shell: pwsh
+
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -7,22 +7,22 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [windows-latest]  # , macos-latest, ubuntu-latest]
         include:
           - os: windows-latest
             platform-name: windows
             asset-name: dcmQTreePy-windows
             path-sep: ";"
 
-          - os: macos-latest
-            platform-name: macos
-            asset-name: dcmQTreePy-macos
-            path-sep: ":"
+          # - os: macos-latest
+          #   platform-name: macos
+          #   asset-name: dcmQTreePy-macos
+          #   path-sep: ":"
 
-          - os: ubuntu-latest
-            platform-name: ubuntu
-            asset-name: dcmQTreePy-ubuntu
-            path-sep: ":"
+          # - os: ubuntu-latest
+          #   platform-name: ubuntu
+          #   asset-name: dcmQTreePy-ubuntu
+          #   path-sep: ":"
 
     runs-on: ${{ matrix.os }}
 
@@ -108,16 +108,16 @@ jobs:
     #     fi
     #   shell: bash
 
-    - name: Build with PyInstaller (macOS)
-      if: matrix.os == 'macos-latest'
-      run: |
-        # poetry run pyinstaller --name=dcmQTreePy --windowed --icon=help/icons/app_icon.png --add-data="help:help" --add-binary="${ASSISTANT_PATH}:." dcmqtreepy/dcmQTree.py
-        poetry run pyinstaller --name=dcmQTreePy --windowed --icon=help/icons/app_icon.png --add-data="help:help" dcmqtreepy/dcmQTree.py
+    # - name: Build with PyInstaller (macOS)
+    #   if: matrix.os == 'macos-latest'
+    #   run: |
+    #     # poetry run pyinstaller --name=dcmQTreePy --windowed --icon=help/icons/app_icon.png --add-data="help:help" --add-binary="${ASSISTANT_PATH}:." dcmqtreepy/dcmQTree.py
+    #     poetry run pyinstaller --name=dcmQTreePy --windowed --icon=help/icons/app_icon.png --add-data="help:help" dcmqtreepy/dcmQTree.py
 
-    - name: Build with PyInstaller (Ubuntu)
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        poetry run pyinstaller --name=dcmQTreePy --windowed --icon=help/icons/app_icon.png --add-data="help:help" dcmqtreepy/dcmQTree.py
+    # - name: Build with PyInstaller (Ubuntu)
+    #   if: matrix.os == 'ubuntu-latest'
+    #   run: |
+    #     poetry run pyinstaller --name=dcmQTreePy --windowed --icon=help/icons/app_icon.png --add-data="help:help" dcmqtreepy/dcmQTree.py
 
     - name: Build with PyInstaller (Windows)
       if: matrix.os == 'windows-latest'
@@ -125,20 +125,20 @@ jobs:
       run: |
         poetry run pyinstaller --name=dcmQTreePy --windowed --icon=help/icons/app_icon.png --add-data="help;help" dcmqtreepy/dcmQTree.py
 
-    - name: Create distribution package (macOS/Linux)
-      if: matrix.os != 'windows-latest'
-      run: |
-        mkdir dist-package
-        if [ "${{ matrix.os }}" = "macos-latest" ]; then
-          cp -r dist/dcmQTreePy.app dist-package/
-          # Create a DMG file for easier distribution
-          hdiutil create -volname dcmQTreePy -srcfolder dist-package -ov -format UDZO dist/dcmQTreePy.dmg
-        elif [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-          cp -r dist/dcmQTreePy dist-package/
-          # Create a tarball for Linux
-          tar -czvf dist/dcmQTreePy-linux.tar.gz -C dist-package .
-        fi
-      shell: bash
+    # - name: Create distribution package (macOS/Linux)
+    #   if: matrix.os != 'windows-latest'
+    #   run: |
+    #     mkdir dist-package
+    #     if [ "${{ matrix.os }}" = "macos-latest" ]; then
+    #       cp -r dist/dcmQTreePy.app dist-package/
+    #       # Create a DMG file for easier distribution
+    #       hdiutil create -volname dcmQTreePy -srcfolder dist-package -ov -format UDZO dist/dcmQTreePy.dmg
+    #     elif [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+    #       cp -r dist/dcmQTreePy dist-package/
+    #       # Create a tarball for Linux
+    #       tar -czvf dist/dcmQTreePy-linux.tar.gz -C dist-package .
+    #     fi
+    #   shell: bash
 
     - name: Create distribution package (Windows)
       if: matrix.os == 'windows-latest'
@@ -162,8 +162,8 @@ jobs:
         name: Release ${{ github.run_number }}
         draft: true
         files: |
-          dist/dcmQTreePy.dmg
-          dist/dcmQTreePy-linux.tar.gz
+          # dist/dcmQTreePy.dmg
+          # dist/dcmQTreePy-linux.tar.gz
           dist/dcmQTreePy-windows.zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -144,9 +144,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       shell: pwsh
       run: |
-        New-Item -Path "dist-package" -ItemType Directory -Force
-        Copy-Item -Path "dist/dcmQTreePy" -Destination "dist-package/" -Recurse
-        Compress-Archive -Path "dist-package/*" -DestinationPath "dist/dcmQTreePy-windows.zip"
+        Compress-Archive -Path "dist/dcmQTreePy.exe" -DestinationPath "dist/dcmQTreePy-windows.zip" -Force
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -55,10 +55,12 @@ jobs:
         sudo apt-get install -y qt6-tools-dev qt6-documentation-tools qt6-base-dev
         echo "ASSISTANT_PATH=$(find /usr -name assistant -type f | grep -v Assistant.app | head -n 1)" >> $GITHUB_ENV
 
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+
     - name: Find Qt Assistant (Windows)
       if: matrix.os == 'windows-latest'
       run: |
-        choco install aqt
         $assistantPath = Get-ChildItem -Path "C:\" -Recurse -Filter "assistant.exe" -ErrorAction SilentlyContinue | Where-Object { $_.FullName -like "*Qt6*" } | Select-Object -First 1 -ExpandProperty FullName
         echo "ASSISTANT_PATH=$assistantPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 

--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -140,12 +140,12 @@ jobs:
     #     fi
     #   shell: bash
 
-    - name: Create distribution package (Windows)
-      if: matrix.os == 'windows-latest'
-      shell: pwsh
-      run: |
-        Compress-Archive -Path "dist/dcmQTreePy.exe" -DestinationPath "dist/dcmQTreePy-windows.zip" -Force
-        Remove-Item -Path "dist/dcmQTreePy.exe" -Force
+    # - name: Create distribution package (Windows)
+    #   if: matrix.os == 'windows-latest'
+    #   shell: pwsh
+    #   run: |
+    #     Compress-Archive -Path "dist/dcmQTreePy.exe" -DestinationPath "dist/dcmQTreePy-windows.zip" -Force
+    #     Remove-Item -Path "dist/dcmQTreePy.exe" -Force
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -65,6 +65,7 @@ jobs:
     #     echo "ASSISTANT_PATH=$assistantPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Install dependencies with Poetry
+      shell: bash
       run: |
         poetry install --with=dev
 
@@ -120,6 +121,7 @@ jobs:
 
     - name: Build with PyInstaller (Windows)
       if: matrix.os == 'windows-latest'
+      shell: bash
       run: |
         poetry run pyinstaller --name=dcmQTreePy --windowed --icon=help/icons/app_icon.png --add-data="help;help" dcmqtreepy/dcmQTree.py
 
@@ -142,10 +144,9 @@ jobs:
       if: matrix.os == 'windows-latest'
       shell: pwsh
       run: |
-        mkdir dist-package
-        cp -r dist/dcmQTreePy dist-package/
-        Compress-Archive -Path dist-package/* -DestinationPath dist/dcmQTreePy-windows.zip
-
+        New-Item -Path "dist-package" -ItemType Directory -Force
+        Copy-Item -Path "dist/dcmQTreePy" -Destination "dist-package/" -Recurse
+        Compress-Archive -Path "dist-package/*" -DestinationPath "dist/dcmQTreePy-windows.zip"
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -145,6 +145,7 @@ jobs:
       shell: pwsh
       run: |
         Compress-Archive -Path "dist/dcmQTreePy.exe" -DestinationPath "dist/dcmQTreePy-windows.zip" -Force
+        Remove-Item -Path "dist/dcmQTreePy.exe" -Force
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4

--- a/dcmqtreepy/dcmQTree.py
+++ b/dcmqtreepy/dcmQTree.py
@@ -869,7 +869,7 @@ if __name__ == "__main__":
     # Set up logging to file
     user_home = Path.home()
     log_path = platformdirs.user_log_dir("dcmQTreePy")  # user_home / "Library" / "Logs" / "dcmQTreePy"
-    log_path.mkdir(parents=True, exist_ok=True)
+    Path(log_path).mkdir(parents=True, exist_ok=True)
     log_file = log_path / "dcmQTreePy.log"
 
     # Configure root logger

--- a/dcmqtreepy/dcmQTree.py
+++ b/dcmqtreepy/dcmQTree.py
@@ -868,9 +868,9 @@ def main():
 if __name__ == "__main__":
     # Set up logging to file
     user_home = Path.home()
-    log_path = platformdirs.user_log_dir("dcmQTreePy")  # user_home / "Library" / "Logs" / "dcmQTreePy"
+    log_path = Path(platformdirs.user_log_dir("dcmQTreePy"))  # user_home / "Library" / "Logs" / "dcmQTreePy"
     Path(log_path).mkdir(parents=True, exist_ok=True)
-    log_file = log_path / "dcmQTreePy.log"
+    log_file = log_path.joinpath("dcmQTreePy.log")
 
     # Configure root logger
     logging.basicConfig(


### PR DESCRIPTION
Commented out everything other than building a windows executable as a single file
Do not attempt to bake in QtAssistant (that just isn't working).

## Summary by Sourcery

Restrict the build-executables workflow to Windows only, remove all Qt Assistant installation and multi-OS packaging steps, and simplify the build to produce a single-file Windows executable.

Enhancements:
- Switch PyInstaller invocation to produce a single-file Windows executable
- Refactor logging directory creation in dcmQTree.py to use pathlib for path operations

CI:
- Limit the build matrix to windows-latest and comment out macOS and Ubuntu jobs
- Remove Qt Assistant install and discovery steps from GitHub Actions
- Update artifact upload to only include the Windows ZIP