### PR TITLE
specify only the dcmQTreePy.exe for creating a release

### DIFF
--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -161,7 +161,7 @@ jobs:
         name: Release ${{ github.run_number }}
         draft: true
         files: |
-          "dist/dcmQTreePy.exe"
+          dist/dcmQTreePy.exe
 
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -157,8 +157,6 @@ jobs:
         name: Release ${{ github.run_number }}
         draft: true
         files: |
-          dist/dcmQTreePy.dmg
-          dist/dcmQTreePy-linux.tar.gz
-          dist/dcmQTreePy-windows.zip
+          "dist/dcmQTreePy.exe"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Restrict the release step to only include the Windows executable (dist/dcmQTreePy.exe)