### PR TITLE
Fix release permission

### DIFF
--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -161,7 +161,7 @@ jobs:
         name: Release ${{ github.run_number }}
         draft: true
         files: |
-          "dist/dcmQTreePy.exe"
+          dist/dcmQTreePy.exe
 
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -3,6 +3,9 @@ name: Build Executables
 on:
   workflow_dispatch:  # Manual trigger
 
+permissions:
+  contents: write  # This allows creating releases and tags
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -157,8 +157,6 @@ jobs:
         name: Release ${{ github.run_number }}
         draft: true
         files: |
-          dist/dcmQTreePy.dmg
-          dist/dcmQTreePy-linux.tar.gz
-          dist/dcmQTreePy-windows.zip
+          "dist/dcmQTreePy.exe"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add contents: write permission to the build-executables GitHub Actions workflow to allow release and tag creation.